### PR TITLE
bugfix: increase specificity of downloadTriggerUrl filter

### DIFF
--- a/teddycloud/rootfs/etc/nginx/servers/ingress.conf
+++ b/teddycloud/rootfs/etc/nginx/servers/ingress.conf
@@ -56,7 +56,7 @@ server {
 	sub_filter '"/img_unknown.png"' '"$http_x_ingress_path/img_unknown.png"';
 	sub_filter 'p.tonieInfo.picture' "[p.tonieInfo.picture.startsWith('http')?'':'$http_x_ingress_path', p.tonieInfo.picture].join('')";
 	sub_filter '""+p.audioUrl' '"$http_x_ingress_path"+p.audioUrl';
-	sub_filter 'p.downloadTriggerUrl' '"$http_x_ingress_path"+p.downloadTriggerUrl';
+	sub_filter 'p.downloadTriggerUrl;' '"$http_x_ingress_path"+p.downloadTriggerUrl;';
 	sub_filter_once off;
 
         proxy_pass http://backend;


### PR DESCRIPTION


# Proposed Changes

previous version of this filter matched two spots. we just want to match the assignment, not where it's used as parameter of useState()

## Related Issues

> #5 
