### PR TITLE
don't rely on minified variable name for web assets

### DIFF
--- a/teddycloud/rootfs/etc/nginx/servers/ingress.conf
+++ b/teddycloud/rootfs/etc/nginx/servers/ingress.conf
@@ -35,7 +35,7 @@ server {
         sub_filter 'apiPostTeddyCloudFormDataRaw(`/api/' 'apiPostTeddyCloudFormDataRaw(`$http_x_ingress_path/api/';
 	sub_filter 'apiPostTeddyCloudRaw(`/content/' 'apiPostTeddyCloudRaw(`$http_x_ingress_path/content/';
 	sub_filter 'loadPath:"/web/' 'loadPath:"$http_x_ingress_path/web/';	
-	sub_filter 'Lq="/web/assets/' 'Lq="$http_x_ingress_path/web/assets/';
+	sub_filter '="/web/assets/' '="$http_x_ingress_path/web/assets/';
 	sub_filter 'REACT_APP_TEDDYCLOUD_WEB_BASE:"/web"' 'REACT_APP_TEDDYCLOUD_WEB_BASE:"$http_x_ingress_path/web"';
         sub_filter 'PUBLIC_URL:"/web"' 'PUBLIC_URL:"$http_x_ingress_path/web"';
         sub_filter 'EventSource("/api/sse")' 'EventSource("$http_x_ingress_path/api/sse")';


### PR DESCRIPTION


# Proposed Changes

- my teddycloud (0.6.2) build used a variable named `bK`:
  ![image](https://github.com/user-attachments/assets/e6c3b2b9-56d2-494c-b5c2-4652c03f83d5)

- this relaxed filter matches multipe relevant spots and the images within the box setup tutorials work as well.
